### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow that publishes the package to PyPI when a GitHub release is created
- Uses trusted publishing (OIDC) — no API token secrets needed, just configure the trusted publisher on pypi.org

## Test plan

- [ ] Configure trusted publisher on pypi.org with repo `MotocredOficial/credere_sdk`, workflow `publish.yml`
- [ ] Create a GitHub release and verify the package is published to PyPI