### PR TITLE
Rename PyPI package to credere-sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "credere"
+name = "credere-sdk"
 version = "0.1.0"
 description = "Python SDK for the Credere credit simulation API"
 readme = "README.md"


### PR DESCRIPTION
## Summary

- Rename the PyPI distribution name from `credere` to `credere-sdk` to avoid name conflicts on PyPI
- The Python import name remains `import credere` (unchanged)

## Test plan

- [ ] Delete the failed GitHub release, then create a new one to trigger the publish workflow
- [ ] Verify `pip install credere-sdk` works after publishing