### PR TITLE
Add Customers resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -10,6 +10,12 @@ from credere.exceptions import (
     NotFoundError,
 )
 from credere.models.bank_credentials import IntegratedBank
+from credere.models.customers import (
+    Customer,
+    CustomerAddress,
+    CustomerAddressRequest,
+    CustomerCreateRequest,
+)
 from credere.models.leads import (
     Address,
     DomainValue,
@@ -62,6 +68,10 @@ __all__ = [
     "CredereConnectionError",
     "CredereError",
     "CredereTimeoutError",
+    "Customer",
+    "CustomerAddress",
+    "CustomerAddressRequest",
+    "CustomerCreateRequest",
     "Domain",
     "DomainValue",
     "IntegratedBank",

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -6,6 +6,7 @@ import httpx
 
 from credere.auth import APIKeyAuth
 from credere.resources.bank_credentials import AsyncBankCredentials, BankCredentials
+from credere.resources.customers import AsyncCustomers, Customers
 from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.plus_returns import AsyncPlusReturns, PlusReturns
 from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
@@ -42,6 +43,7 @@ class CredereClient:
         self.proposals = Proposals(self._http, store_id=store_id)
         self.simulations = Simulations(self._http, store_id=store_id)
         self.bank_credentials = BankCredentials(self._http, store_id=store_id)
+        self.customers = Customers(self._http, store_id=store_id)
         self.plus_returns = PlusReturns(self._http, store_id=store_id)
         self.stock = Stock(self._http, store_id=store_id)
         self.utilities = Utilities(self._http, store_id=store_id)
@@ -81,6 +83,7 @@ class AsyncCredereClient:
         self.proposals = AsyncProposals(self._http, store_id=store_id)
         self.simulations = AsyncSimulations(self._http, store_id=store_id)
         self.bank_credentials = AsyncBankCredentials(self._http, store_id=store_id)
+        self.customers = AsyncCustomers(self._http, store_id=store_id)
         self.plus_returns = AsyncPlusReturns(self._http, store_id=store_id)
         self.stock = AsyncStock(self._http, store_id=store_id)
         self.utilities = AsyncUtilities(self._http, store_id=store_id)

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -1,6 +1,12 @@
 """Pydantic models for the Credere SDK."""
 
 from credere.models.bank_credentials import IntegratedBank
+from credere.models.customers import (
+    Customer,
+    CustomerAddress,
+    CustomerAddressRequest,
+    CustomerCreateRequest,
+)
 from credere.models.leads import (
     Address,
     DomainValue,
@@ -46,6 +52,10 @@ from credere.models.vehicle_models import (
 __all__ = [
     "Address",
     "Bank",
+    "Customer",
+    "CustomerAddress",
+    "CustomerAddressRequest",
+    "CustomerCreateRequest",
     "Domain",
     "DomainValue",
     "IntegratedBank",

--- a/src/credere/models/customers.py
+++ b/src/credere/models/customers.py
@@ -1,0 +1,74 @@
+"""Pydantic models for the Customers resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CustomerAddressRequest(BaseModel):
+    """Address input for customer create/update requests."""
+
+    model_config = ConfigDict(extra="allow")
+
+    zip_code: str | None = None
+    street: str | None = None
+    number: str | None = None
+    complement: str | None = None
+    district: str | None = None
+    city: str | None = None
+    state: str | None = None
+
+
+class CustomerAddress(BaseModel):
+    """Address as returned in customer responses (includes id)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    zip_code: str | None = None
+    street: str | None = None
+    number: str | None = None
+    complement: str | None = None
+    district: str | None = None
+    city: str | None = None
+    state: str | None = None
+
+
+class CustomerCreateRequest(BaseModel):
+    """Input model for creating or updating a customer."""
+
+    model_config = ConfigDict(extra="allow")
+
+    cpf_cnpj: str | None = None
+    name: str | None = None
+    birthdate: str | None = None
+    email: str | None = None
+    phone_number: str | None = None
+    gender: str | None = None
+    profession: str | None = None
+    monthly_income: int | None = None
+    mother_name: str | None = None
+    address: CustomerAddressRequest | None = None
+
+
+class Customer(BaseModel):
+    """Customer as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    object_type: str | None = None
+    cpf_cnpj: str | None = None
+    name: str | None = None
+    email: str | None = None
+    birthdate: str | None = None
+    phone_number: str | None = None
+    gender: dict | None = None
+    profession: dict | None = None
+    occupation: dict | None = None
+    monthly_income: int | None = None
+    mother_name: str | None = None
+    address: CustomerAddress | None = None
+    active: bool | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -1,6 +1,7 @@
 """Resource classes for the Credere SDK."""
 
 from credere.resources.bank_credentials import AsyncBankCredentials, BankCredentials
+from credere.resources.customers import AsyncCustomers, Customers
 from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.plus_returns import AsyncPlusReturns, PlusReturns
 from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
@@ -14,6 +15,7 @@ from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 __all__ = [
     "AsyncBankCredentials",
+    "AsyncCustomers",
     "AsyncLeads",
     "AsyncPlusReturns",
     "AsyncProposalAttempts",
@@ -25,6 +27,7 @@ __all__ = [
     "AsyncUtilities",
     "AsyncVehicleModels",
     "BankCredentials",
+    "Customers",
     "Leads",
     "PlusReturns",
     "ProposalAttempts",

--- a/src/credere/resources/customers.py
+++ b/src/credere/resources/customers.py
@@ -1,0 +1,206 @@
+"""Sync and async resource classes for the Customers endpoint."""
+
+from __future__ import annotations
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.customers import Customer, CustomerCreateRequest
+
+_BASE_PATH = "/v1/customers"
+
+
+class Customers:
+    """Synchronous customers resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def create(
+        self,
+        data: CustomerCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> Customer:
+        try:
+            response = self._client.post(
+                _BASE_PATH,
+                json={"customer": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Customer.model_validate(response.json()["customer"])
+
+    def update(
+        self,
+        id: int,
+        data: CustomerCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> Customer:
+        try:
+            response = self._client.patch(
+                f"{_BASE_PATH}/{id}",
+                json={"customer": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Customer.model_validate(response.json()["customer"])
+
+    def list(self, *, store_id: int | None = None) -> list[Customer]:
+        try:
+            response = self._client.get(
+                _BASE_PATH,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Customer.model_validate(item) for item in response.json()["customers"]]
+
+    def get(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> Customer:
+        try:
+            response = self._client.get(
+                f"{_BASE_PATH}/{id}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Customer.model_validate(response.json()["customer"])
+
+    def find(
+        self,
+        *,
+        store_id: int | None = None,
+        **params: str,
+    ) -> Customer:
+        try:
+            response = self._client.get(
+                f"{_BASE_PATH}/find",
+                params=params,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Customer.model_validate(response.json()["customer"])
+
+
+class AsyncCustomers:
+    """Asynchronous customers resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def create(
+        self,
+        data: CustomerCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> Customer:
+        try:
+            response = await self._client.post(
+                _BASE_PATH,
+                json={"customer": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Customer.model_validate(response.json()["customer"])
+
+    async def update(
+        self,
+        id: int,
+        data: CustomerCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> Customer:
+        try:
+            response = await self._client.patch(
+                f"{_BASE_PATH}/{id}",
+                json={"customer": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Customer.model_validate(response.json()["customer"])
+
+    async def list(self, *, store_id: int | None = None) -> list[Customer]:
+        try:
+            response = await self._client.get(
+                _BASE_PATH,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Customer.model_validate(item) for item in response.json()["customers"]]
+
+    async def get(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> Customer:
+        try:
+            response = await self._client.get(
+                f"{_BASE_PATH}/{id}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Customer.model_validate(response.json()["customer"])
+
+    async def find(
+        self,
+        *,
+        store_id: int | None = None,
+        **params: str,
+    ) -> Customer:
+        try:
+            response = await self._client.get(
+                f"{_BASE_PATH}/find",
+                params=params,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Customer.model_validate(response.json()["customer"])

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -1,0 +1,290 @@
+"""Tests for the Customers resource (sync + async)."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError, NotFoundError
+from credere.models.customers import Customer, CustomerCreateRequest
+
+BASE_URL = "https://api.credere.com"
+CUSTOMERS_URL = f"{BASE_URL}/v1/customers"
+
+SAMPLE_CUSTOMER_RESPONSE = {
+    "customer": {
+        "id": 1,
+        "object_type": "Customer",
+        "cpf_cnpj": "12345678901",
+        "name": "Maria Souza",
+        "email": "maria@example.com",
+        "birthdate": "1985-05-20",
+        "phone_number": "11988887777",
+        "gender": {
+            "id": 2,
+            "type": "Gender",
+            "credere_identifier": "female",
+            "label": "Feminino",
+        },
+        "profession": {
+            "id": 30,
+            "type": "Profession",
+            "credere_identifier": "lawyer",
+            "label": "Advogado",
+        },
+        "occupation": {
+            "id": 15,
+            "type": "Occupation",
+            "credere_identifier": "self_employed",
+            "label": "Autônomo",
+        },
+        "monthly_income": 800000,
+        "mother_name": "Ana Souza",
+        "address": {
+            "id": 200,
+            "zip_code": "04001000",
+            "street": "Av. Paulista",
+            "number": "1000",
+            "complement": "Sala 101",
+            "district": "Bela Vista",
+            "city": "São Paulo",
+            "state": "SP",
+        },
+        "active": True,
+        "created_at": "2024-06-01T10:00:00-03:00",
+        "updated_at": "2024-06-01T10:00:00-03:00",
+    }
+}
+
+SAMPLE_LIST_RESPONSE = {"customers": [SAMPLE_CUSTOMER_RESPONSE["customer"]]}
+
+SAMPLE_CREATE_DATA = CustomerCreateRequest(
+    cpf_cnpj="12345678901",
+    name="Maria Souza",
+    email="maria@example.com",
+    birthdate="1985-05-20",
+    phone_number="11988887777",
+    monthly_income=800000,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestCustomersCreate:
+    @respx.mock
+    def test_create_customer(self, sync_client: CredereClient) -> None:
+        route = respx.post(CUSTOMERS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        customer = sync_client.customers.create(SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(customer, Customer)
+        assert customer.id == 1
+        assert customer.cpf_cnpj == "12345678901"
+        assert customer.name == "Maria Souza"
+        assert customer.email == "maria@example.com"
+        assert customer.active is True
+        assert customer.address is not None
+        assert customer.address.id == 200
+
+    @respx.mock
+    def test_create_sends_correct_body(self, sync_client: CredereClient) -> None:
+        route = respx.post(CUSTOMERS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        sync_client.customers.create(SAMPLE_CREATE_DATA)
+
+        request = route.calls.last.request
+        body = json.loads(request.content)
+        assert "customer" in body
+        assert body["customer"]["cpf_cnpj"] == "12345678901"
+        assert body["customer"]["name"] == "Maria Souza"
+
+    @respx.mock
+    def test_create_sends_store_id_header(self, sync_client: CredereClient) -> None:
+        route = respx.post(CUSTOMERS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        sync_client.customers.create(SAMPLE_CREATE_DATA)
+
+        request = route.calls.last.request
+        assert request.headers["Store-Id"] == "42"
+
+
+class TestCustomersUpdate:
+    @respx.mock
+    def test_update_customer(self, sync_client: CredereClient) -> None:
+        url = f"{CUSTOMERS_URL}/1"
+        route = respx.patch(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        update_data = CustomerCreateRequest(name="Maria Atualizada")
+        customer = sync_client.customers.update(1, update_data)
+
+        assert route.called
+        assert isinstance(customer, Customer)
+        assert customer.id == 1
+
+    @respx.mock
+    def test_update_sends_correct_body(self, sync_client: CredereClient) -> None:
+        url = f"{CUSTOMERS_URL}/1"
+        route = respx.patch(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        sync_client.customers.update(1, CustomerCreateRequest(name="Maria Atualizada"))
+
+        request = route.calls.last.request
+        body = json.loads(request.content)
+        assert "customer" in body
+        assert body["customer"]["name"] == "Maria Atualizada"
+
+
+class TestCustomersList:
+    @respx.mock
+    def test_list_customers(self, sync_client: CredereClient) -> None:
+        route = respx.get(CUSTOMERS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_LIST_RESPONSE)
+        )
+
+        customers = sync_client.customers.list()
+
+        assert route.called
+        assert isinstance(customers, list)
+        assert len(customers) == 1
+        assert isinstance(customers[0], Customer)
+        assert customers[0].cpf_cnpj == "12345678901"
+
+
+class TestCustomersGet:
+    @respx.mock
+    def test_get_customer(self, sync_client: CredereClient) -> None:
+        url = f"{CUSTOMERS_URL}/1"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        customer = sync_client.customers.get(1)
+
+        assert route.called
+        assert isinstance(customer, Customer)
+        assert customer.id == 1
+        assert customer.mother_name == "Ana Souza"
+
+
+class TestCustomersFind:
+    @respx.mock
+    def test_find_customer(self, sync_client: CredereClient) -> None:
+        url = f"{CUSTOMERS_URL}/find"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        customer = sync_client.customers.find(cpf_cnpj="12345678901")
+
+        assert route.called
+        assert isinstance(customer, Customer)
+        assert customer.id == 1
+        assert customer.cpf_cnpj == "12345678901"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        respx.get(CUSTOMERS_URL).mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.customers.list()
+
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    def test_404_raises_not_found_error(self, sync_client: CredereClient) -> None:
+        url = f"{CUSTOMERS_URL}/99999"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "message": "Endpoint requested not found",
+                        "status": 404,
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(NotFoundError) as exc_info:
+            sync_client.customers.get(99999)
+
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncCustomersCreate:
+    @respx.mock
+    async def test_async_create_customer(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.post(CUSTOMERS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        customer = await async_client.customers.create(SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(customer, Customer)
+        assert customer.id == 1
+        assert customer.cpf_cnpj == "12345678901"
+
+
+class TestAsyncCustomersList:
+    @respx.mock
+    async def test_async_list_customers(self, async_client: AsyncCredereClient) -> None:
+        route = respx.get(CUSTOMERS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_LIST_RESPONSE)
+        )
+
+        customers = await async_client.customers.list()
+
+        assert route.called
+        assert len(customers) == 1
+        assert isinstance(customers[0], Customer)
+
+
+class TestAsyncCustomersGet:
+    @respx.mock
+    async def test_async_get_customer(self, async_client: AsyncCredereClient) -> None:
+        url = f"{CUSTOMERS_URL}/1"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CUSTOMER_RESPONSE)
+        )
+
+        customer = await async_client.customers.get(1)
+
+        assert route.called
+        assert isinstance(customer, Customer)
+        assert customer.id == 1


### PR DESCRIPTION
## Summary
- Add `Customers` and `AsyncCustomers` resource classes with create, update, list, get, and find endpoints
- Add Pydantic models: `Customer`, `CustomerAddress`, `CustomerAddressRequest`, `CustomerCreateRequest`
- Wire into `CredereClient` / `AsyncCredereClient` and re-export from package

## Test plan
- [x] Sync tests for all 5 endpoints (create, update, list, get, find)
- [x] Error mapping tests (401, 404)
- [x] Async tests (create, list, get)