### PR TITLE
Add Proposal Attempts resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -17,6 +17,10 @@ from credere.models.leads import (
     LeadCreateRequest,
     LeadRequiredFields,
 )
+from credere.models.proposal_attempts import (
+    ProposalAttempt,
+    ProposalAttemptCreateRequest,
+)
 from credere.models.proposals import (
     Proposal,
     ProposalCondition,
@@ -60,6 +64,8 @@ __all__ = [
     "LeadRequiredFields",
     "NotFoundError",
     "Proposal",
+    "ProposalAttempt",
+    "ProposalAttemptCreateRequest",
     "ProposalCondition",
     "ProposalConditionRequest",
     "ProposalCreateRequest",

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -6,6 +6,7 @@ import httpx
 
 from credere.auth import APIKeyAuth
 from credere.resources.leads import AsyncLeads, Leads
+from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
 from credere.resources.stores import AsyncStores, Stores
@@ -36,6 +37,7 @@ class CredereClient:
         self.proposals = Proposals(self._http, store_id=store_id)
         self.simulations = Simulations(self._http, store_id=store_id)
         self.vehicle_models = VehicleModels(self._http, store_id=store_id)
+        self.proposal_attempts = ProposalAttempts(self._http, store_id=store_id)
         self.stores = Stores(self._http, store_id=store_id)
 
     def close(self) -> None:
@@ -69,6 +71,7 @@ class AsyncCredereClient:
         self.proposals = AsyncProposals(self._http, store_id=store_id)
         self.simulations = AsyncSimulations(self._http, store_id=store_id)
         self.vehicle_models = AsyncVehicleModels(self._http, store_id=store_id)
+        self.proposal_attempts = AsyncProposalAttempts(self._http, store_id=store_id)
         self.stores = AsyncStores(self._http, store_id=store_id)
 
     async def close(self) -> None:

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -8,6 +8,10 @@ from credere.models.leads import (
     LeadCreateRequest,
     LeadRequiredFields,
 )
+from credere.models.proposal_attempts import (
+    ProposalAttempt,
+    ProposalAttemptCreateRequest,
+)
 from credere.models.proposals import (
     Proposal,
     ProposalCondition,
@@ -43,6 +47,8 @@ __all__ = [
     "LeadCreateRequest",
     "LeadRequiredFields",
     "Proposal",
+    "ProposalAttempt",
+    "ProposalAttemptCreateRequest",
     "ProposalCondition",
     "ProposalConditionRequest",
     "ProposalCreateRequest",

--- a/src/credere/models/proposal_attempts.py
+++ b/src/credere/models/proposal_attempts.py
@@ -1,0 +1,21 @@
+"""Pydantic models for the Proposal Attempts resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ProposalAttemptCreateRequest(BaseModel):
+    """Input model for creating or updating a proposal attempt."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ProposalAttempt(BaseModel):
+    """Proposal attempt as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -1,6 +1,7 @@
 """Resource classes for the Credere SDK."""
 
 from credere.resources.leads import AsyncLeads, Leads
+from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
 from credere.resources.stores import AsyncStores, Stores
@@ -8,11 +9,13 @@ from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 __all__ = [
     "AsyncLeads",
+    "AsyncProposalAttempts",
     "AsyncProposals",
     "AsyncSimulations",
     "AsyncStores",
     "AsyncVehicleModels",
     "Leads",
+    "ProposalAttempts",
     "Proposals",
     "Simulations",
     "Stores",

--- a/src/credere/resources/proposal_attempts.py
+++ b/src/credere/resources/proposal_attempts.py
@@ -1,0 +1,233 @@
+"""Sync and async resource classes for the Proposal Attempts endpoint."""
+
+from __future__ import annotations
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.proposal_attempts import (
+    ProposalAttempt,
+    ProposalAttemptCreateRequest,
+)
+
+
+def _base_path(proposal_id: str) -> str:
+    return f"/v1/proposals/{proposal_id}/proposal_attempts"
+
+
+class ProposalAttempts:
+    """Synchronous proposal attempts resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def create(
+        self,
+        proposal_id: str,
+        data: ProposalAttemptCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> ProposalAttempt:
+        try:
+            response = self._client.post(
+                _base_path(proposal_id),
+                json=data.model_dump(exclude_none=True),
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return ProposalAttempt.model_validate(response.json()["data"])
+
+    def list(
+        self,
+        proposal_id: str,
+        *,
+        store_id: int | None = None,
+    ) -> list[ProposalAttempt]:
+        try:
+            response = self._client.get(
+                _base_path(proposal_id),
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [
+            ProposalAttempt.model_validate(item) for item in response.json()["data"]
+        ]
+
+    def get(
+        self,
+        proposal_id: str,
+        id: str,
+        *,
+        store_id: int | None = None,
+    ) -> ProposalAttempt:
+        try:
+            response = self._client.get(
+                f"{_base_path(proposal_id)}/{id}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return ProposalAttempt.model_validate(response.json()["data"])
+
+    def update(
+        self,
+        proposal_id: str,
+        id: str,
+        data: ProposalAttemptCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> ProposalAttempt:
+        try:
+            response = self._client.put(
+                f"{_base_path(proposal_id)}/{id}",
+                json=data.model_dump(exclude_none=True),
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return ProposalAttempt.model_validate(response.json()["data"])
+
+    def perform_action(
+        self,
+        proposal_id: str,
+        id: str,
+        action: str,
+        *,
+        store_id: int | None = None,
+    ) -> ProposalAttempt:
+        try:
+            response = self._client.get(
+                f"{_base_path(proposal_id)}/{id}/{action}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return ProposalAttempt.model_validate(response.json()["data"])
+
+
+class AsyncProposalAttempts:
+    """Asynchronous proposal attempts resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def create(
+        self,
+        proposal_id: str,
+        data: ProposalAttemptCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> ProposalAttempt:
+        try:
+            response = await self._client.post(
+                _base_path(proposal_id),
+                json=data.model_dump(exclude_none=True),
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return ProposalAttempt.model_validate(response.json()["data"])
+
+    async def list(
+        self,
+        proposal_id: str,
+        *,
+        store_id: int | None = None,
+    ) -> list[ProposalAttempt]:
+        try:
+            response = await self._client.get(
+                _base_path(proposal_id),
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [
+            ProposalAttempt.model_validate(item) for item in response.json()["data"]
+        ]
+
+    async def get(
+        self,
+        proposal_id: str,
+        id: str,
+        *,
+        store_id: int | None = None,
+    ) -> ProposalAttempt:
+        try:
+            response = await self._client.get(
+                f"{_base_path(proposal_id)}/{id}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return ProposalAttempt.model_validate(response.json()["data"])
+
+    async def update(
+        self,
+        proposal_id: str,
+        id: str,
+        data: ProposalAttemptCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> ProposalAttempt:
+        try:
+            response = await self._client.put(
+                f"{_base_path(proposal_id)}/{id}",
+                json=data.model_dump(exclude_none=True),
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return ProposalAttempt.model_validate(response.json()["data"])
+
+    async def perform_action(
+        self,
+        proposal_id: str,
+        id: str,
+        action: str,
+        *,
+        store_id: int | None = None,
+    ) -> ProposalAttempt:
+        try:
+            response = await self._client.get(
+                f"{_base_path(proposal_id)}/{id}/{action}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return ProposalAttempt.model_validate(response.json()["data"])

--- a/tests/test_proposal_attempts.py
+++ b/tests/test_proposal_attempts.py
@@ -1,0 +1,207 @@
+"""Tests for the Proposal Attempts resource (sync + async)."""
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError, NotFoundError
+from credere.models.proposal_attempts import (
+    ProposalAttempt,
+    ProposalAttemptCreateRequest,
+)
+
+BASE_URL = "https://api.credere.com"
+PROPOSAL_ID = "abc-123"
+ATTEMPTS_URL = f"{BASE_URL}/v1/proposals/{PROPOSAL_ID}/proposal_attempts"
+
+SAMPLE_ATTEMPT_RESPONSE = {
+    "data": {
+        "id": 1,
+        "created_at": "2024-01-15T10:00:00-03:00",
+        "updated_at": "2024-01-15T10:00:00-03:00",
+    }
+}
+
+SAMPLE_LIST_RESPONSE = {"data": [SAMPLE_ATTEMPT_RESPONSE["data"]]}
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestProposalAttemptsCreate:
+    @respx.mock
+    def test_create_proposal_attempt(self, sync_client: CredereClient) -> None:
+        route = respx.post(ATTEMPTS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_ATTEMPT_RESPONSE)
+        )
+
+        result = sync_client.proposal_attempts.create(
+            PROPOSAL_ID, ProposalAttemptCreateRequest()
+        )
+
+        assert route.called
+        assert isinstance(result, ProposalAttempt)
+        assert result.id == 1
+
+
+class TestProposalAttemptsList:
+    @respx.mock
+    def test_list_proposal_attempts(self, sync_client: CredereClient) -> None:
+        route = respx.get(ATTEMPTS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_LIST_RESPONSE)
+        )
+
+        result = sync_client.proposal_attempts.list(PROPOSAL_ID)
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], ProposalAttempt)
+        assert result[0].id == 1
+
+
+class TestProposalAttemptsGet:
+    @respx.mock
+    def test_get_proposal_attempt(self, sync_client: CredereClient) -> None:
+        url = f"{ATTEMPTS_URL}/1"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_ATTEMPT_RESPONSE)
+        )
+
+        result = sync_client.proposal_attempts.get(PROPOSAL_ID, 1)
+
+        assert route.called
+        assert isinstance(result, ProposalAttempt)
+        assert result.id == 1
+
+
+class TestProposalAttemptsUpdate:
+    @respx.mock
+    def test_update_proposal_attempt(self, sync_client: CredereClient) -> None:
+        url = f"{ATTEMPTS_URL}/1"
+        route = respx.put(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_ATTEMPT_RESPONSE)
+        )
+
+        result = sync_client.proposal_attempts.update(
+            PROPOSAL_ID, 1, ProposalAttemptCreateRequest()
+        )
+
+        assert route.called
+        assert isinstance(result, ProposalAttempt)
+        assert result.id == 1
+
+
+class TestProposalAttemptsPerformAction:
+    @respx.mock
+    def test_perform_action_approve(self, sync_client: CredereClient) -> None:
+        url = f"{ATTEMPTS_URL}/1/approve"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_ATTEMPT_RESPONSE)
+        )
+
+        result = sync_client.proposal_attempts.perform_action(PROPOSAL_ID, 1, "approve")
+
+        assert route.called
+        assert isinstance(result, ProposalAttempt)
+        assert result.id == 1
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        respx.get(ATTEMPTS_URL).mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.proposal_attempts.list(PROPOSAL_ID)
+
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    def test_404_raises_not_found_error(self, sync_client: CredereClient) -> None:
+        respx.get(ATTEMPTS_URL).mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "message": "Endpoint requested not found",
+                        "status": 404,
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(NotFoundError) as exc_info:
+            sync_client.proposal_attempts.list(PROPOSAL_ID)
+
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncProposalAttemptsCreate:
+    @respx.mock
+    async def test_async_create_proposal_attempt(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.post(ATTEMPTS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_ATTEMPT_RESPONSE)
+        )
+
+        result = await async_client.proposal_attempts.create(
+            PROPOSAL_ID, ProposalAttemptCreateRequest()
+        )
+
+        assert route.called
+        assert isinstance(result, ProposalAttempt)
+        assert result.id == 1
+
+
+class TestAsyncProposalAttemptsList:
+    @respx.mock
+    async def test_async_list_proposal_attempts(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.get(ATTEMPTS_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_LIST_RESPONSE)
+        )
+
+        result = await async_client.proposal_attempts.list(PROPOSAL_ID)
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], ProposalAttempt)
+
+
+class TestAsyncProposalAttemptsGet:
+    @respx.mock
+    async def test_async_get_proposal_attempt(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        url = f"{ATTEMPTS_URL}/1"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_ATTEMPT_RESPONSE)
+        )
+
+        result = await async_client.proposal_attempts.get(PROPOSAL_ID, 1)
+
+        assert route.called
+        assert isinstance(result, ProposalAttempt)
+        assert result.id == 1


### PR DESCRIPTION
## Summary
- Add `ProposalAttempts` and `AsyncProposalAttempts` resource classes with create, list, get, update, and perform_action endpoints
- Add Pydantic models: `ProposalAttempt`, `ProposalAttemptCreateRequest`
- Nested under proposals path (`/v1/proposals/{proposal_id}/proposal_attempts`)

## Test plan
- [x] Sync tests for all 5 endpoints (create, list, get, update, perform_action)
- [x] Error mapping tests (401, 404)
- [x] Async tests (create, list, get)