### PR TITLE
Add Stores resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -33,6 +33,7 @@ from credere.models.simulations import (
     SimulationCreateRequest,
     SimulationVehicleRequest,
 )
+from credere.models.stores import Store, StoreCreateRequest
 from credere.models.vehicle_models import (
     VehicleBrand,
     VehicleFuel,
@@ -69,6 +70,8 @@ __all__ = [
     "SimulationConditionRequest",
     "SimulationCreateRequest",
     "SimulationVehicleRequest",
+    "Store",
+    "StoreCreateRequest",
     "VehicleBrand",
     "VehicleFuel",
     "VehicleModel",

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -8,6 +8,7 @@ from credere.auth import APIKeyAuth
 from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
+from credere.resources.stores import AsyncStores, Stores
 from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 _DEFAULT_BASE_URL = "https://api.credere.com"
@@ -35,6 +36,7 @@ class CredereClient:
         self.proposals = Proposals(self._http, store_id=store_id)
         self.simulations = Simulations(self._http, store_id=store_id)
         self.vehicle_models = VehicleModels(self._http, store_id=store_id)
+        self.stores = Stores(self._http, store_id=store_id)
 
     def close(self) -> None:
         self._http.close()
@@ -67,6 +69,7 @@ class AsyncCredereClient:
         self.proposals = AsyncProposals(self._http, store_id=store_id)
         self.simulations = AsyncSimulations(self._http, store_id=store_id)
         self.vehicle_models = AsyncVehicleModels(self._http, store_id=store_id)
+        self.stores = AsyncStores(self._http, store_id=store_id)
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -24,6 +24,7 @@ from credere.models.simulations import (
     SimulationCreateRequest,
     SimulationVehicleRequest,
 )
+from credere.models.stores import Store, StoreCreateRequest
 from credere.models.vehicle_models import (
     VehicleBrand,
     VehicleFuel,
@@ -52,6 +53,8 @@ __all__ = [
     "SimulationConditionRequest",
     "SimulationCreateRequest",
     "SimulationVehicleRequest",
+    "Store",
+    "StoreCreateRequest",
     "VehicleBrand",
     "VehicleFuel",
     "VehicleModel",

--- a/src/credere/models/stores.py
+++ b/src/credere/models/stores.py
@@ -1,0 +1,39 @@
+"""Pydantic models for the Stores resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class StoreCreateRequest(BaseModel):
+    """Input model for creating a store."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str | None = None
+    display_name: str | None = None
+    cnpj: str | None = None
+    _persist_cnpj_bank_credentials: bool | None = None
+
+
+class Store(BaseModel):
+    """Store as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    object_type: str | None = None
+    name: str | None = None
+    display_name: str | None = None
+    uf: str | None = None
+    city: str | None = None
+    cnpj: str | None = None
+    new_vehicle_sales: bool | None = None
+    used_vehicle_sales: bool | None = None
+    publish: bool | None = None
+    public_api_identifier: str | None = None
+    avatar: dict | None = None
+    limit_fi_performance_visibility: bool | None = None
+    limit_simulation_bank_visibility: bool | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -3,15 +3,18 @@
 from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
+from credere.resources.stores import AsyncStores, Stores
 from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 __all__ = [
     "AsyncLeads",
     "AsyncProposals",
     "AsyncSimulations",
+    "AsyncStores",
     "AsyncVehicleModels",
     "Leads",
     "Proposals",
     "Simulations",
+    "Stores",
     "VehicleModels",
 ]

--- a/src/credere/resources/stores.py
+++ b/src/credere/resources/stores.py
@@ -1,0 +1,180 @@
+"""Sync and async resource classes for the Stores endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.stores import Store, StoreCreateRequest
+
+_BASE_PATH = "/v1/stores"
+
+
+class Stores:
+    """Synchronous stores resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def create(
+        self,
+        data: StoreCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> Store:
+        try:
+            response = self._client.post(
+                _BASE_PATH,
+                json={"store": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Store.model_validate(response.json()["store"])
+
+    def list(
+        self,
+        *,
+        store_id: int | None = None,
+        **params: Any,
+    ) -> list[Store]:
+        try:
+            response = self._client.get(
+                _BASE_PATH,
+                params=params or None,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Store.model_validate(item) for item in response.json()["stores"]]
+
+    def activate(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> Store:
+        try:
+            response = self._client.get(
+                f"{_BASE_PATH}/{id}/activate",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Store.model_validate(response.json()["store"])
+
+    def deactivate(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> Store:
+        try:
+            response = self._client.get(
+                f"{_BASE_PATH}/{id}/deactivate",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Store.model_validate(response.json()["store"])
+
+
+class AsyncStores:
+    """Asynchronous stores resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def create(
+        self,
+        data: StoreCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> Store:
+        try:
+            response = await self._client.post(
+                _BASE_PATH,
+                json={"store": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Store.model_validate(response.json()["store"])
+
+    async def list(
+        self,
+        *,
+        store_id: int | None = None,
+        **params: Any,
+    ) -> list[Store]:
+        try:
+            response = await self._client.get(
+                _BASE_PATH,
+                params=params or None,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Store.model_validate(item) for item in response.json()["stores"]]
+
+    async def activate(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> Store:
+        try:
+            response = await self._client.get(
+                f"{_BASE_PATH}/{id}/activate",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Store.model_validate(response.json()["store"])
+
+    async def deactivate(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> Store:
+        try:
+            response = await self._client.get(
+                f"{_BASE_PATH}/{id}/deactivate",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return Store.model_validate(response.json()["store"])

--- a/tests/test_stores.py
+++ b/tests/test_stores.py
@@ -1,0 +1,176 @@
+"""Tests for the Stores resource (sync + async)."""
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError, NotFoundError
+from credere.models.stores import Store, StoreCreateRequest
+
+BASE_URL = "https://api.credere.com"
+STORES_URL = f"{BASE_URL}/v1/stores"
+
+SAMPLE_STORE_RESPONSE = {
+    "store": {
+        "id": 1,
+        "name": "Test Store",
+        "display_name": "Test",
+        "cnpj": "12345678000100",
+        "created_at": "2024-01-15T10:00:00-03:00",
+        "updated_at": "2024-01-15T10:00:00-03:00",
+    }
+}
+
+SAMPLE_LIST_RESPONSE = {"stores": [SAMPLE_STORE_RESPONSE["store"]]}
+
+SAMPLE_CREATE_DATA = StoreCreateRequest(
+    name="Test Store",
+    display_name="Test",
+    cnpj="12345678000100",
+)
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestStoresCreate:
+    @respx.mock
+    def test_create_store(self, sync_client: CredereClient) -> None:
+        route = respx.post(STORES_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_STORE_RESPONSE)
+        )
+
+        result = sync_client.stores.create(SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(result, Store)
+        assert result.id == 1
+        assert result.name == "Test Store"
+        assert result.display_name == "Test"
+        assert result.cnpj == "12345678000100"
+
+
+class TestStoresList:
+    @respx.mock
+    def test_list_stores(self, sync_client: CredereClient) -> None:
+        route = respx.get(STORES_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_LIST_RESPONSE)
+        )
+
+        result = sync_client.stores.list()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], Store)
+        assert result[0].name == "Test Store"
+
+
+class TestStoresActivate:
+    @respx.mock
+    def test_activate_store(self, sync_client: CredereClient) -> None:
+        url = f"{STORES_URL}/1/activate"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_STORE_RESPONSE)
+        )
+
+        result = sync_client.stores.activate(1)
+
+        assert route.called
+        assert isinstance(result, Store)
+        assert result.name == "Test Store"
+
+
+class TestStoresDeactivate:
+    @respx.mock
+    def test_deactivate_store(self, sync_client: CredereClient) -> None:
+        url = f"{STORES_URL}/1/deactivate"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_STORE_RESPONSE)
+        )
+
+        result = sync_client.stores.deactivate(1)
+
+        assert route.called
+        assert isinstance(result, Store)
+        assert result.name == "Test Store"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        respx.get(STORES_URL).mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.stores.list()
+
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    def test_404_raises_not_found_error(self, sync_client: CredereClient) -> None:
+        url = f"{STORES_URL}/999/activate"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "message": "Endpoint requested not found",
+                        "status": 404,
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(NotFoundError) as exc_info:
+            sync_client.stores.activate(999)
+
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncStoresCreate:
+    @respx.mock
+    async def test_async_create_store(self, async_client: AsyncCredereClient) -> None:
+        route = respx.post(STORES_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_STORE_RESPONSE)
+        )
+
+        result = await async_client.stores.create(SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(result, Store)
+        assert result.id == 1
+        assert result.name == "Test Store"
+
+
+class TestAsyncStoresList:
+    @respx.mock
+    async def test_async_list_stores(self, async_client: AsyncCredereClient) -> None:
+        route = respx.get(STORES_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_LIST_RESPONSE)
+        )
+
+        result = await async_client.stores.list()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], Store)
+        assert result[0].name == "Test Store"


### PR DESCRIPTION
## Summary
- Add `Stores` and `AsyncStores` resource classes with create, list, activate, and deactivate endpoints
- Add Pydantic models: `Store`, `StoreCreateRequest`
- Wire into `CredereClient` / `AsyncCredereClient` and re-export from package

## Test plan
- [x] Sync tests for all 4 endpoints (create, list, activate, deactivate)
- [x] Error mapping tests (401, 404)
- [x] Async tests (create, list)