### PR TITLE
Add Users resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -38,6 +38,7 @@ from credere.models.simulations import (
     SimulationVehicleRequest,
 )
 from credere.models.stores import Store, StoreCreateRequest
+from credere.models.users import User, UserAccount, UserRole
 from credere.models.vehicle_models import (
     VehicleBrand,
     VehicleFuel,
@@ -78,6 +79,9 @@ __all__ = [
     "SimulationVehicleRequest",
     "Store",
     "StoreCreateRequest",
+    "User",
+    "UserAccount",
+    "UserRole",
     "VehicleBrand",
     "VehicleFuel",
     "VehicleModel",

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -10,6 +10,7 @@ from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalA
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
 from credere.resources.stores import AsyncStores, Stores
+from credere.resources.users import AsyncUsers, Users
 from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 _DEFAULT_BASE_URL = "https://api.credere.com"
@@ -39,6 +40,7 @@ class CredereClient:
         self.vehicle_models = VehicleModels(self._http, store_id=store_id)
         self.proposal_attempts = ProposalAttempts(self._http, store_id=store_id)
         self.stores = Stores(self._http, store_id=store_id)
+        self.users = Users(self._http, store_id=store_id)
 
     def close(self) -> None:
         self._http.close()
@@ -73,6 +75,7 @@ class AsyncCredereClient:
         self.vehicle_models = AsyncVehicleModels(self._http, store_id=store_id)
         self.proposal_attempts = AsyncProposalAttempts(self._http, store_id=store_id)
         self.stores = AsyncStores(self._http, store_id=store_id)
+        self.users = AsyncUsers(self._http, store_id=store_id)
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -29,6 +29,7 @@ from credere.models.simulations import (
     SimulationVehicleRequest,
 )
 from credere.models.stores import Store, StoreCreateRequest
+from credere.models.users import User, UserAccount, UserRole
 from credere.models.vehicle_models import (
     VehicleBrand,
     VehicleFuel,
@@ -61,6 +62,9 @@ __all__ = [
     "SimulationVehicleRequest",
     "Store",
     "StoreCreateRequest",
+    "User",
+    "UserAccount",
+    "UserRole",
     "VehicleBrand",
     "VehicleFuel",
     "VehicleModel",

--- a/src/credere/models/users.py
+++ b/src/credere/models/users.py
@@ -1,0 +1,46 @@
+"""Pydantic models for the Users resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class UserRole(BaseModel):
+    """User role as returned in user responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    identifier: str | None = None
+    name: str | None = None
+
+
+class UserAccount(BaseModel):
+    """User account as returned in user responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    name: str | None = None
+    active: bool | None = None
+    send_sms: bool | None = None
+    state: str | None = None
+    beta_until: str | None = None
+
+
+class User(BaseModel):
+    """User as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    name: str | None = None
+    email: str | None = None
+    cpf: str | None = None
+    account_name: str | None = None
+    role: UserRole | None = None
+    account: UserAccount | None = None
+    avatar: dict | None = None
+    active_alerts: dict | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -5,6 +5,7 @@ from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalA
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
 from credere.resources.stores import AsyncStores, Stores
+from credere.resources.users import AsyncUsers, Users
 from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 __all__ = [
@@ -13,11 +14,13 @@ __all__ = [
     "AsyncProposals",
     "AsyncSimulations",
     "AsyncStores",
+    "AsyncUsers",
     "AsyncVehicleModels",
     "Leads",
     "ProposalAttempts",
     "Proposals",
     "Simulations",
     "Stores",
+    "Users",
     "VehicleModels",
 ]

--- a/src/credere/resources/users.py
+++ b/src/credere/resources/users.py
@@ -1,0 +1,88 @@
+"""Sync and async resource classes for the Users endpoint."""
+
+from __future__ import annotations
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.users import User
+
+_BASE_PATH = "/v1/users"
+
+
+class Users:
+    """Synchronous users resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def current(self) -> User:
+        try:
+            response = self._client.get(f"{_BASE_PATH}/current")
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return User.model_validate(response.json()["user"])
+
+    def proposals_filter_list(
+        self,
+        *,
+        store_id: int | None = None,
+    ) -> list[User]:
+        try:
+            response = self._client.get(
+                f"{_BASE_PATH}/proposals_filter_list",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [User.model_validate(item) for item in response.json()["users"]]
+
+
+class AsyncUsers:
+    """Asynchronous users resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def current(self) -> User:
+        try:
+            response = await self._client.get(f"{_BASE_PATH}/current")
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return User.model_validate(response.json()["user"])
+
+    async def proposals_filter_list(
+        self,
+        *,
+        store_id: int | None = None,
+    ) -> list[User]:
+        try:
+            response = await self._client.get(
+                f"{_BASE_PATH}/proposals_filter_list",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [User.model_validate(item) for item in response.json()["users"]]

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,146 @@
+"""Tests for the Users resource (sync + async)."""
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError
+from credere.models.users import User
+
+BASE_URL = "https://api.credere.com"
+USERS_URL = f"{BASE_URL}/v1/users"
+
+SAMPLE_USER = {
+    "id": 1,
+    "name": "John",
+    "email": "john@example.com",
+    "cpf": "12345678901",
+    "created_at": "2024-01-15T10:00:00-03:00",
+    "updated_at": "2024-01-15T10:00:00-03:00",
+}
+
+SAMPLE_CURRENT_RESPONSE = {"user": SAMPLE_USER}
+SAMPLE_PROPOSALS_FILTER_LIST_RESPONSE = {"users": [SAMPLE_USER]}
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestUsersCurrent:
+    @respx.mock
+    def test_current_returns_user(self, sync_client: CredereClient) -> None:
+        url = f"{USERS_URL}/current"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CURRENT_RESPONSE)
+        )
+
+        result = sync_client.users.current()
+
+        assert route.called
+        assert isinstance(result, User)
+        assert result.id == 1
+        assert result.name == "John"
+        assert result.email == "john@example.com"
+        assert result.cpf == "12345678901"
+
+
+class TestUsersProposalsFilterList:
+    @respx.mock
+    def test_proposals_filter_list_returns_list_of_users(
+        self, sync_client: CredereClient
+    ) -> None:
+        url = f"{USERS_URL}/proposals_filter_list"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_PROPOSALS_FILTER_LIST_RESPONSE)
+        )
+
+        result = sync_client.users.proposals_filter_list()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], User)
+        assert result[0].name == "John"
+
+    @respx.mock
+    def test_proposals_filter_list_sends_store_id_header(
+        self, sync_client: CredereClient
+    ) -> None:
+        url = f"{USERS_URL}/proposals_filter_list"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_PROPOSALS_FILTER_LIST_RESPONSE)
+        )
+
+        sync_client.users.proposals_filter_list()
+
+        request = route.calls.last.request
+        assert request.headers["Store-Id"] == "42"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        url = f"{USERS_URL}/current"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.users.current()
+
+        assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncUsersCurrent:
+    @respx.mock
+    async def test_async_current_returns_user(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        url = f"{USERS_URL}/current"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_CURRENT_RESPONSE)
+        )
+
+        result = await async_client.users.current()
+
+        assert route.called
+        assert isinstance(result, User)
+        assert result.id == 1
+        assert result.name == "John"
+        assert result.email == "john@example.com"
+        assert result.cpf == "12345678901"
+
+
+class TestAsyncUsersProposalsFilterList:
+    @respx.mock
+    async def test_async_proposals_filter_list_returns_list_of_users(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        url = f"{USERS_URL}/proposals_filter_list"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_PROPOSALS_FILTER_LIST_RESPONSE)
+        )
+
+        result = await async_client.users.proposals_filter_list()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], User)
+        assert result[0].name == "John"


### PR DESCRIPTION
## Summary
- Add `Users` and `AsyncUsers` resource classes with current and proposals_filter_list endpoints
- Add Pydantic models: `User`, `UserAccount`, `UserRole`
- Wire into `CredereClient` / `AsyncCredereClient` and re-export from package

## Test plan
- [x] Sync tests for both endpoints (current, proposals_filter_list)
- [x] Error mapping test (401)
- [x] Async tests (current, proposals_filter_list)