### PR TITLE
Add Vehicle Models resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -25,6 +25,14 @@ from credere.models.simulations import (
     SimulationCreateRequest,
     SimulationVehicleRequest,
 )
+from credere.models.vehicle_models import (
+    VehicleBrand,
+    VehicleFuel,
+    VehicleModel,
+    VehiclePrice,
+    VehiclePriceStore,
+    VehicleType,
+)
 
 __all__ = [
     "Address",
@@ -47,4 +55,10 @@ __all__ = [
     "SimulationConditionRequest",
     "SimulationCreateRequest",
     "SimulationVehicleRequest",
+    "VehicleBrand",
+    "VehicleFuel",
+    "VehicleModel",
+    "VehiclePrice",
+    "VehiclePriceStore",
+    "VehicleType",
 ]

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -7,6 +7,7 @@ import httpx
 from credere.auth import APIKeyAuth
 from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.simulations import AsyncSimulations, Simulations
+from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 _DEFAULT_BASE_URL = "https://api.credere.com"
 _DEFAULT_TIMEOUT = 30.0
@@ -31,6 +32,7 @@ class CredereClient:
         )
         self.leads = Leads(self._http, store_id=store_id)
         self.simulations = Simulations(self._http, store_id=store_id)
+        self.vehicle_models = VehicleModels(self._http, store_id=store_id)
 
     def close(self) -> None:
         self._http.close()
@@ -61,6 +63,7 @@ class AsyncCredereClient:
         )
         self.leads = AsyncLeads(self._http, store_id=store_id)
         self.simulations = AsyncSimulations(self._http, store_id=store_id)
+        self.vehicle_models = AsyncVehicleModels(self._http, store_id=store_id)
 
     async def close(self) -> None:
         await self._http.aclose()

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -16,6 +16,14 @@ from credere.models.simulations import (
     SimulationCreateRequest,
     SimulationVehicleRequest,
 )
+from credere.models.vehicle_models import (
+    VehicleBrand,
+    VehicleFuel,
+    VehicleModel,
+    VehiclePrice,
+    VehiclePriceStore,
+    VehicleType,
+)
 
 __all__ = [
     "Address",
@@ -30,4 +38,10 @@ __all__ = [
     "SimulationConditionRequest",
     "SimulationCreateRequest",
     "SimulationVehicleRequest",
+    "VehicleBrand",
+    "VehicleFuel",
+    "VehicleModel",
+    "VehiclePrice",
+    "VehiclePriceStore",
+    "VehicleType",
 ]

--- a/src/credere/models/vehicle_models.py
+++ b/src/credere/models/vehicle_models.py
@@ -1,0 +1,91 @@
+"""Pydantic models for the Vehicle Models resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class VehicleBrand(BaseModel):
+    """Vehicle brand as returned in vehicle model responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    name: str | None = None
+
+
+class VehicleFuel(BaseModel):
+    """Vehicle fuel type as returned in vehicle model responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    name: str | None = None
+    object_type: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class VehicleType(BaseModel):
+    """Vehicle type as returned in vehicle model responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    name: str | None = None
+
+
+class VehicleModel(BaseModel):
+    """Vehicle model as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    object_type: str | None = None
+    name: str | None = None
+    brand: str | None = None
+    molicar_code: str | None = None
+    version: str | None = None
+    year_start: int | None = None
+    year_end: int | None = None
+    active: bool | None = None
+    public_price_cents: int | None = None
+    public_price_as_string: str | None = None
+    publish: bool | None = None
+    fipe_code: str | None = None
+    public_picture: str | None = None
+    vehicle_brand: VehicleBrand | None = None
+    fuel: VehicleFuel | None = None
+    vehicle_type: VehicleType | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class VehiclePriceStore(BaseModel):
+    """Store as returned in vehicle price responses."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    name: str | None = None
+    display_name: str | None = None
+    uf: str | None = None
+    limit_vehicle_prices: bool | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class VehiclePrice(BaseModel):
+    """Vehicle price as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    store_id: int | None = None
+    min_price_cents: int | None = None
+    default_price_cents: int | None = None
+    active: bool | None = None
+    vehicle_model: VehicleModel | None = None
+    store: VehiclePriceStore | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -2,10 +2,13 @@
 
 from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.simulations import AsyncSimulations, Simulations
+from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 __all__ = [
     "AsyncLeads",
     "AsyncSimulations",
+    "AsyncVehicleModels",
     "Leads",
     "Simulations",
+    "VehicleModels",
 ]

--- a/src/credere/resources/vehicle_models.py
+++ b/src/credere/resources/vehicle_models.py
@@ -1,0 +1,165 @@
+"""Sync and async resource classes for the Vehicle Models endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.vehicle_models import VehicleModel, VehiclePrice
+
+_MODELS_PATH = "/v1/vehicle_models"
+_PRICES_PATH = "/v1/vehicle_prices"
+
+
+class VehicleModels:
+    """Synchronous vehicle models resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def list(
+        self,
+        *,
+        store_id: int | None = None,
+        **params: Any,
+    ) -> list[VehicleModel]:
+        try:
+            response = self._client.get(
+                _MODELS_PATH,
+                params=params or None,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [
+            VehicleModel.model_validate(item)
+            for item in response.json()["vehicle_models"]
+        ]
+
+    def search(
+        self,
+        q: str,
+        *,
+        store_id: int | None = None,
+        **params: Any,
+    ) -> VehicleModel:
+        params["q"] = q
+        try:
+            response = self._client.get(
+                f"{_MODELS_PATH}/search",
+                params=params,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return VehicleModel.model_validate(response.json()["vehicle_model"])
+
+    def prices(
+        self,
+        *,
+        store_id: int | None = None,
+        **params: Any,
+    ) -> list[VehiclePrice]:
+        try:
+            response = self._client.get(
+                _PRICES_PATH,
+                params=params or None,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [
+            VehiclePrice.model_validate(item)
+            for item in response.json()["vehicle_prices"]
+        ]
+
+
+class AsyncVehicleModels:
+    """Asynchronous vehicle models resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def list(
+        self,
+        *,
+        store_id: int | None = None,
+        **params: Any,
+    ) -> list[VehicleModel]:
+        try:
+            response = await self._client.get(
+                _MODELS_PATH,
+                params=params or None,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [
+            VehicleModel.model_validate(item)
+            for item in response.json()["vehicle_models"]
+        ]
+
+    async def search(
+        self,
+        q: str,
+        *,
+        store_id: int | None = None,
+        **params: Any,
+    ) -> VehicleModel:
+        params["q"] = q
+        try:
+            response = await self._client.get(
+                f"{_MODELS_PATH}/search",
+                params=params,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return VehicleModel.model_validate(response.json()["vehicle_model"])
+
+    async def prices(
+        self,
+        *,
+        store_id: int | None = None,
+        **params: Any,
+    ) -> list[VehiclePrice]:
+        try:
+            response = await self._client.get(
+                _PRICES_PATH,
+                params=params or None,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [
+            VehiclePrice.model_validate(item)
+            for item in response.json()["vehicle_prices"]
+        ]

--- a/tests/test_vehicle_models.py
+++ b/tests/test_vehicle_models.py
@@ -1,0 +1,164 @@
+"""Tests for the Vehicle Models resource (sync + async)."""
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError
+from credere.models.vehicle_models import VehicleModel, VehiclePrice
+
+BASE_URL = "https://api.credere.com"
+MODELS_URL = f"{BASE_URL}/v1/vehicle_models"
+PRICES_URL = f"{BASE_URL}/v1/vehicle_prices"
+
+SAMPLE_VEHICLE_MODEL = {
+    "id": 1,
+    "name": "Civic",
+    "brand": "Honda",
+    "molicar_code": "123456",
+    "active": True,
+}
+
+SAMPLE_VEHICLE_PRICE = {
+    "id": 1,
+    "store_id": 42,
+    "min_price_cents": 5000000,
+    "default_price_cents": 6000000,
+    "active": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestVehicleModelsList:
+    @respx.mock
+    def test_list_returns_vehicle_models(self, sync_client: CredereClient) -> None:
+        route = respx.get(MODELS_URL).mock(
+            return_value=httpx.Response(
+                200, json={"vehicle_models": [SAMPLE_VEHICLE_MODEL]}
+            )
+        )
+
+        result = sync_client.vehicle_models.list()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], VehicleModel)
+        assert result[0].id == 1
+        assert result[0].name == "Civic"
+        assert result[0].brand == "Honda"
+        assert result[0].molicar_code == "123456"
+        assert result[0].active is True
+
+
+class TestVehicleModelsSearch:
+    @respx.mock
+    def test_search_returns_vehicle_model(self, sync_client: CredereClient) -> None:
+        route = respx.get(f"{MODELS_URL}/search").mock(
+            return_value=httpx.Response(
+                200, json={"vehicle_model": SAMPLE_VEHICLE_MODEL}
+            )
+        )
+
+        result = sync_client.vehicle_models.search("Civic")
+
+        assert route.called
+        assert isinstance(result, VehicleModel)
+        assert result.id == 1
+        assert result.name == "Civic"
+        assert result.brand == "Honda"
+        assert result.molicar_code == "123456"
+        assert result.active is True
+
+
+class TestVehicleModelsPrices:
+    @respx.mock
+    def test_prices_returns_vehicle_prices(self, sync_client: CredereClient) -> None:
+        route = respx.get(PRICES_URL).mock(
+            return_value=httpx.Response(
+                200, json={"vehicle_prices": [SAMPLE_VEHICLE_PRICE]}
+            )
+        )
+
+        result = sync_client.vehicle_models.prices()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], VehiclePrice)
+        assert result[0].id == 1
+        assert result[0].store_id == 42
+        assert result[0].min_price_cents == 5000000
+        assert result[0].default_price_cents == 6000000
+        assert result[0].active is True
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        respx.get(MODELS_URL).mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.vehicle_models.list()
+
+        assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncVehicleModelsList:
+    @respx.mock
+    async def test_async_list_returns_vehicle_models(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.get(MODELS_URL).mock(
+            return_value=httpx.Response(
+                200, json={"vehicle_models": [SAMPLE_VEHICLE_MODEL]}
+            )
+        )
+
+        result = await async_client.vehicle_models.list()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], VehicleModel)
+        assert result[0].id == 1
+        assert result[0].name == "Civic"
+
+
+class TestAsyncVehicleModelsSearch:
+    @respx.mock
+    async def test_async_search_returns_vehicle_model(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.get(f"{MODELS_URL}/search").mock(
+            return_value=httpx.Response(
+                200, json={"vehicle_model": SAMPLE_VEHICLE_MODEL}
+            )
+        )
+
+        result = await async_client.vehicle_models.search("Civic")
+
+        assert route.called
+        assert isinstance(result, VehicleModel)
+        assert result.id == 1
+        assert result.name == "Civic"


### PR DESCRIPTION
## Summary
- Add `VehicleModels` and `AsyncVehicleModels` resource classes with list, search, and prices endpoints
- Add Pydantic models: `VehicleBrand`, `VehicleFuel`, `VehicleModel`, `VehiclePrice`, `VehiclePriceStore`, `VehicleType`
- Wire into `CredereClient` / `AsyncCredereClient` and re-export from package

## Test plan
- [x] Sync tests for all 3 endpoints (list, search, prices)
- [x] Error mapping test (401)
- [x] Async tests (list, search)