### PR TITLE
Add Utilities resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -39,6 +39,7 @@ from credere.models.simulations import (
 )
 from credere.models.stores import Store, StoreCreateRequest
 from credere.models.users import User, UserAccount, UserRole
+from credere.models.utilities import Domain
 from credere.models.vehicle_models import (
     VehicleBrand,
     VehicleFuel,
@@ -58,6 +59,7 @@ __all__ = [
     "CredereConnectionError",
     "CredereError",
     "CredereTimeoutError",
+    "Domain",
     "DomainValue",
     "Lead",
     "LeadAddress",

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -11,6 +11,7 @@ from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
 from credere.resources.stores import AsyncStores, Stores
 from credere.resources.users import AsyncUsers, Users
+from credere.resources.utilities import AsyncUtilities, Utilities
 from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 _DEFAULT_BASE_URL = "https://api.credere.com"
@@ -37,6 +38,7 @@ class CredereClient:
         self.leads = Leads(self._http, store_id=store_id)
         self.proposals = Proposals(self._http, store_id=store_id)
         self.simulations = Simulations(self._http, store_id=store_id)
+        self.utilities = Utilities(self._http, store_id=store_id)
         self.vehicle_models = VehicleModels(self._http, store_id=store_id)
         self.proposal_attempts = ProposalAttempts(self._http, store_id=store_id)
         self.stores = Stores(self._http, store_id=store_id)
@@ -72,6 +74,7 @@ class AsyncCredereClient:
         self.leads = AsyncLeads(self._http, store_id=store_id)
         self.proposals = AsyncProposals(self._http, store_id=store_id)
         self.simulations = AsyncSimulations(self._http, store_id=store_id)
+        self.utilities = AsyncUtilities(self._http, store_id=store_id)
         self.vehicle_models = AsyncVehicleModels(self._http, store_id=store_id)
         self.proposal_attempts = AsyncProposalAttempts(self._http, store_id=store_id)
         self.stores = AsyncStores(self._http, store_id=store_id)

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -30,6 +30,7 @@ from credere.models.simulations import (
 )
 from credere.models.stores import Store, StoreCreateRequest
 from credere.models.users import User, UserAccount, UserRole
+from credere.models.utilities import Domain
 from credere.models.vehicle_models import (
     VehicleBrand,
     VehicleFuel,
@@ -42,6 +43,7 @@ from credere.models.vehicle_models import (
 __all__ = [
     "Address",
     "Bank",
+    "Domain",
     "DomainValue",
     "Lead",
     "LeadAddress",

--- a/src/credere/models/utilities.py
+++ b/src/credere/models/utilities.py
@@ -1,0 +1,16 @@
+"""Pydantic models for the Utilities resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Domain(BaseModel):
+    """Domain value used for client and lead domains."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    type: str | None = None
+    credere_identifier: str | None = None
+    label: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -6,6 +6,7 @@ from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
 from credere.resources.stores import AsyncStores, Stores
 from credere.resources.users import AsyncUsers, Users
+from credere.resources.utilities import AsyncUtilities, Utilities
 from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 __all__ = [
@@ -15,6 +16,7 @@ __all__ = [
     "AsyncSimulations",
     "AsyncStores",
     "AsyncUsers",
+    "AsyncUtilities",
     "AsyncVehicleModels",
     "Leads",
     "ProposalAttempts",
@@ -22,5 +24,6 @@ __all__ = [
     "Simulations",
     "Stores",
     "Users",
+    "Utilities",
     "VehicleModels",
 ]

--- a/src/credere/resources/utilities.py
+++ b/src/credere/resources/utilities.py
@@ -1,0 +1,179 @@
+"""Sync and async resource classes for the Utilities endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.simulations import Bank
+from credere.models.utilities import Domain
+
+
+class Utilities:
+    """Synchronous utilities resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def domains(self, *, store_id: int | None = None) -> list[Domain]:
+        try:
+            response = self._client.get(
+                "/v1/domains",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Domain.model_validate(item) for item in response.json()]
+
+    def lead_domains(self, *, store_id: int | None = None) -> list[Domain]:
+        try:
+            response = self._client.get(
+                "/v1/banks_api/domains",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Domain.model_validate(item) for item in response.json()]
+
+    def banks(self, *, store_id: int | None = None) -> list[Bank]:
+        try:
+            response = self._client.get(
+                "/v1/banks",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Bank.model_validate(item) for item in response.json()["banks"]]
+
+    def vehicle_by_plate(
+        self,
+        plate: str,
+        *,
+        store_id: int | None = None,
+    ) -> dict[str, Any]:
+        try:
+            response = self._client.get(
+                f"/v1/vehicles/license_plate/{plate}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return response.json()
+
+    def vehicle_by_chassis(
+        self,
+        chassi: str,
+        *,
+        store_id: int | None = None,
+    ) -> dict[str, Any]:
+        try:
+            response = self._client.get(
+                f"/v1/vehicles/chassi_code/{chassi}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return response.json()
+
+
+class AsyncUtilities:
+    """Asynchronous utilities resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def domains(self, *, store_id: int | None = None) -> list[Domain]:
+        try:
+            response = await self._client.get(
+                "/v1/domains",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Domain.model_validate(item) for item in response.json()]
+
+    async def lead_domains(self, *, store_id: int | None = None) -> list[Domain]:
+        try:
+            response = await self._client.get(
+                "/v1/banks_api/domains",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Domain.model_validate(item) for item in response.json()]
+
+    async def banks(self, *, store_id: int | None = None) -> list[Bank]:
+        try:
+            response = await self._client.get(
+                "/v1/banks",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [Bank.model_validate(item) for item in response.json()["banks"]]
+
+    async def vehicle_by_plate(
+        self,
+        plate: str,
+        *,
+        store_id: int | None = None,
+    ) -> dict[str, Any]:
+        try:
+            response = await self._client.get(
+                f"/v1/vehicles/license_plate/{plate}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return response.json()
+
+    async def vehicle_by_chassis(
+        self,
+        chassi: str,
+        *,
+        store_id: int | None = None,
+    ) -> dict[str, Any]:
+        try:
+            response = await self._client.get(
+                f"/v1/vehicles/chassi_code/{chassi}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return response.json()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,190 @@
+"""Tests for the Utilities resource (sync + async)."""
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError
+from credere.models.simulations import Bank
+from credere.models.utilities import Domain
+
+BASE_URL = "https://api.credere.com"
+
+SAMPLE_DOMAIN = {
+    "id": 1,
+    "type": "gender",
+    "credere_identifier": "male",
+    "label": "Masculino",
+}
+
+SAMPLE_BANK = {
+    "id": 1,
+    "febraban_code": "001",
+    "name": "Banco do Brasil",
+    "nickname": "BB",
+}
+
+SAMPLE_VEHICLE = {"name": "Civic", "brand": "Honda"}
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestUtilitiesDomains:
+    @respx.mock
+    def test_domains_returns_list_of_domain(self, sync_client: CredereClient) -> None:
+        route = respx.get(f"{BASE_URL}/v1/domains").mock(
+            return_value=httpx.Response(200, json=[SAMPLE_DOMAIN])
+        )
+
+        result = sync_client.utilities.domains()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], Domain)
+        assert result[0].id == 1
+        assert result[0].type == "gender"
+        assert result[0].credere_identifier == "male"
+        assert result[0].label == "Masculino"
+
+
+class TestUtilitiesLeadDomains:
+    @respx.mock
+    def test_lead_domains_returns_list_of_domain(
+        self, sync_client: CredereClient
+    ) -> None:
+        route = respx.get(f"{BASE_URL}/v1/banks_api/domains").mock(
+            return_value=httpx.Response(200, json=[SAMPLE_DOMAIN])
+        )
+
+        result = sync_client.utilities.lead_domains()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], Domain)
+        assert result[0].id == 1
+        assert result[0].type == "gender"
+        assert result[0].credere_identifier == "male"
+        assert result[0].label == "Masculino"
+
+
+class TestUtilitiesBanks:
+    @respx.mock
+    def test_banks_returns_list_of_bank(self, sync_client: CredereClient) -> None:
+        route = respx.get(f"{BASE_URL}/v1/banks").mock(
+            return_value=httpx.Response(200, json={"banks": [SAMPLE_BANK]})
+        )
+
+        result = sync_client.utilities.banks()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], Bank)
+        assert result[0].id == 1
+        assert result[0].febraban_code == "001"
+        assert result[0].name == "Banco do Brasil"
+        assert result[0].nickname == "BB"
+
+
+class TestUtilitiesVehicleByPlate:
+    @respx.mock
+    def test_vehicle_by_plate_returns_dict(self, sync_client: CredereClient) -> None:
+        route = respx.get(f"{BASE_URL}/v1/vehicles/license_plate/ABC1234").mock(
+            return_value=httpx.Response(200, json=SAMPLE_VEHICLE)
+        )
+
+        result = sync_client.utilities.vehicle_by_plate("ABC1234")
+
+        assert route.called
+        assert isinstance(result, dict)
+        assert result["name"] == "Civic"
+        assert result["brand"] == "Honda"
+
+
+class TestUtilitiesVehicleByChassis:
+    @respx.mock
+    def test_vehicle_by_chassis_returns_dict(self, sync_client: CredereClient) -> None:
+        route = respx.get(f"{BASE_URL}/v1/vehicles/chassi_code/9BWZZZ377VT004251").mock(
+            return_value=httpx.Response(200, json=SAMPLE_VEHICLE)
+        )
+
+        result = sync_client.utilities.vehicle_by_chassis("9BWZZZ377VT004251")
+
+        assert route.called
+        assert isinstance(result, dict)
+        assert result["name"] == "Civic"
+        assert result["brand"] == "Honda"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        respx.get(f"{BASE_URL}/v1/domains").mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.utilities.domains()
+
+        assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncUtilitiesDomains:
+    @respx.mock
+    async def test_async_domains_returns_list_of_domain(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.get(f"{BASE_URL}/v1/domains").mock(
+            return_value=httpx.Response(200, json=[SAMPLE_DOMAIN])
+        )
+
+        result = await async_client.utilities.domains()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], Domain)
+        assert result[0].id == 1
+        assert result[0].type == "gender"
+        assert result[0].credere_identifier == "male"
+        assert result[0].label == "Masculino"
+
+
+class TestAsyncUtilitiesBanks:
+    @respx.mock
+    async def test_async_banks_returns_list_of_bank(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.get(f"{BASE_URL}/v1/banks").mock(
+            return_value=httpx.Response(200, json={"banks": [SAMPLE_BANK]})
+        )
+
+        result = await async_client.utilities.banks()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], Bank)
+        assert result[0].id == 1
+        assert result[0].febraban_code == "001"
+        assert result[0].name == "Banco do Brasil"
+        assert result[0].nickname == "BB"


### PR DESCRIPTION
## Summary
- Add `Utilities` and `AsyncUtilities` resource classes with domains, lead_domains, banks, vehicle_by_plate, and vehicle_by_chassis endpoints
- Add Pydantic model: `Domain` (reuses `Bank` from simulations module)
- Wire into `CredereClient` / `AsyncCredereClient` and re-export from package

## Test plan
- [x] Sync tests for all 5 endpoints
- [x] Error mapping test (401)
- [x] Async tests (domains, banks)