### PR TITLE
Add Stock resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -37,6 +37,7 @@ from credere.models.simulations import (
     SimulationCreateRequest,
     SimulationVehicleRequest,
 )
+from credere.models.stock import StockVehicle, StockVehicleCreateRequest
 from credere.models.stores import Store, StoreCreateRequest
 from credere.models.users import User, UserAccount, UserRole
 from credere.models.utilities import Domain
@@ -79,6 +80,8 @@ __all__ = [
     "SimulationConditionRequest",
     "SimulationCreateRequest",
     "SimulationVehicleRequest",
+    "StockVehicle",
+    "StockVehicleCreateRequest",
     "Store",
     "StoreCreateRequest",
     "User",

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -9,6 +9,7 @@ from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
+from credere.resources.stock import AsyncStock, Stock
 from credere.resources.stores import AsyncStores, Stores
 from credere.resources.users import AsyncUsers, Users
 from credere.resources.utilities import AsyncUtilities, Utilities
@@ -38,6 +39,7 @@ class CredereClient:
         self.leads = Leads(self._http, store_id=store_id)
         self.proposals = Proposals(self._http, store_id=store_id)
         self.simulations = Simulations(self._http, store_id=store_id)
+        self.stock = Stock(self._http, store_id=store_id)
         self.utilities = Utilities(self._http, store_id=store_id)
         self.vehicle_models = VehicleModels(self._http, store_id=store_id)
         self.proposal_attempts = ProposalAttempts(self._http, store_id=store_id)
@@ -74,6 +76,7 @@ class AsyncCredereClient:
         self.leads = AsyncLeads(self._http, store_id=store_id)
         self.proposals = AsyncProposals(self._http, store_id=store_id)
         self.simulations = AsyncSimulations(self._http, store_id=store_id)
+        self.stock = AsyncStock(self._http, store_id=store_id)
         self.utilities = AsyncUtilities(self._http, store_id=store_id)
         self.vehicle_models = AsyncVehicleModels(self._http, store_id=store_id)
         self.proposal_attempts = AsyncProposalAttempts(self._http, store_id=store_id)

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -28,6 +28,7 @@ from credere.models.simulations import (
     SimulationCreateRequest,
     SimulationVehicleRequest,
 )
+from credere.models.stock import StockVehicle, StockVehicleCreateRequest
 from credere.models.stores import Store, StoreCreateRequest
 from credere.models.users import User, UserAccount, UserRole
 from credere.models.utilities import Domain
@@ -62,6 +63,8 @@ __all__ = [
     "SimulationConditionRequest",
     "SimulationCreateRequest",
     "SimulationVehicleRequest",
+    "StockVehicle",
+    "StockVehicleCreateRequest",
     "Store",
     "StoreCreateRequest",
     "User",

--- a/src/credere/models/stock.py
+++ b/src/credere/models/stock.py
@@ -1,0 +1,28 @@
+"""Pydantic models for the Stock / Inventory resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class StockVehicleCreateRequest(BaseModel):
+    """Input model for creating or updating a stock vehicle."""
+
+    model_config = ConfigDict(extra="allow")
+
+    vehicle_model_id: int | None = None
+    store_id: int | None = None
+    price_cents: int | None = None
+    description: str | None = None
+
+
+class StockVehicle(BaseModel):
+    """Stock vehicle as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    price_cents: int | None = None
+    description: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -4,6 +4,7 @@ from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
+from credere.resources.stock import AsyncStock, Stock
 from credere.resources.stores import AsyncStores, Stores
 from credere.resources.users import AsyncUsers, Users
 from credere.resources.utilities import AsyncUtilities, Utilities
@@ -14,6 +15,7 @@ __all__ = [
     "AsyncProposalAttempts",
     "AsyncProposals",
     "AsyncSimulations",
+    "AsyncStock",
     "AsyncStores",
     "AsyncUsers",
     "AsyncUtilities",
@@ -22,6 +24,7 @@ __all__ = [
     "ProposalAttempts",
     "Proposals",
     "Simulations",
+    "Stock",
     "Stores",
     "Users",
     "Utilities",

--- a/src/credere/resources/stock.py
+++ b/src/credere/resources/stock.py
@@ -1,0 +1,170 @@
+"""Sync and async resource classes for the Stock / Inventory endpoint."""
+
+from __future__ import annotations
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.stock import StockVehicle, StockVehicleCreateRequest
+
+_BASE_PATH = "/v1/vehicles"
+
+
+class Stock:
+    """Synchronous stock resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def create(
+        self,
+        data: StockVehicleCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> StockVehicle:
+        try:
+            response = self._client.post(
+                _BASE_PATH,
+                json={"vehicle": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return StockVehicle.model_validate(response.json()["vehicle"])
+
+    def list(self, *, store_id: int | None = None) -> list[StockVehicle]:
+        try:
+            response = self._client.get(
+                _BASE_PATH,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [StockVehicle.model_validate(item) for item in response.json()]
+
+    def update(
+        self,
+        id: int,
+        data: StockVehicleCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> StockVehicle:
+        try:
+            response = self._client.put(
+                f"{_BASE_PATH}/{id}",
+                json={"vehicle": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return StockVehicle.model_validate(response.json()["vehicle"])
+
+    def remove(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> StockVehicle:
+        try:
+            response = self._client.put(
+                f"{_BASE_PATH}/{id}/remove_from_stock",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return StockVehicle.model_validate(response.json()["vehicle"])
+
+
+class AsyncStock:
+    """Asynchronous stock resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def create(
+        self,
+        data: StockVehicleCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> StockVehicle:
+        try:
+            response = await self._client.post(
+                _BASE_PATH,
+                json={"vehicle": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return StockVehicle.model_validate(response.json()["vehicle"])
+
+    async def list(self, *, store_id: int | None = None) -> list[StockVehicle]:
+        try:
+            response = await self._client.get(
+                _BASE_PATH,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [StockVehicle.model_validate(item) for item in response.json()]
+
+    async def update(
+        self,
+        id: int,
+        data: StockVehicleCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> StockVehicle:
+        try:
+            response = await self._client.put(
+                f"{_BASE_PATH}/{id}",
+                json={"vehicle": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return StockVehicle.model_validate(response.json()["vehicle"])
+
+    async def remove(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> StockVehicle:
+        try:
+            response = await self._client.put(
+                f"{_BASE_PATH}/{id}/remove_from_stock",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return StockVehicle.model_validate(response.json()["vehicle"])

--- a/tests/test_stock.py
+++ b/tests/test_stock.py
@@ -1,0 +1,184 @@
+"""Tests for the Stock resource (sync + async)."""
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError, NotFoundError
+from credere.models.stock import StockVehicle, StockVehicleCreateRequest
+
+BASE_URL = "https://api.credere.com"
+VEHICLES_URL = f"{BASE_URL}/v1/vehicles"
+
+SAMPLE_VEHICLE = {
+    "id": 1,
+    "price_cents": 5000000,
+    "description": "Test vehicle",
+    "created_at": "2024-01-15T10:00:00-03:00",
+    "updated_at": "2024-01-15T10:00:00-03:00",
+}
+
+SAMPLE_CREATE_DATA = StockVehicleCreateRequest(
+    vehicle_model_id=10,
+    store_id=42,
+    price_cents=5000000,
+    description="Test vehicle",
+)
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestStockCreate:
+    @respx.mock
+    def test_create_returns_stock_vehicle(self, sync_client: CredereClient) -> None:
+        route = respx.post(VEHICLES_URL).mock(
+            return_value=httpx.Response(200, json={"vehicle": SAMPLE_VEHICLE})
+        )
+
+        vehicle = sync_client.stock.create(SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(vehicle, StockVehicle)
+        assert vehicle.id == 1
+        assert vehicle.price_cents == 5000000
+        assert vehicle.description == "Test vehicle"
+
+
+class TestStockList:
+    @respx.mock
+    def test_list_returns_stock_vehicles(self, sync_client: CredereClient) -> None:
+        route = respx.get(VEHICLES_URL).mock(
+            return_value=httpx.Response(200, json=[SAMPLE_VEHICLE])
+        )
+
+        vehicles = sync_client.stock.list()
+
+        assert route.called
+        assert isinstance(vehicles, list)
+        assert len(vehicles) == 1
+        assert isinstance(vehicles[0], StockVehicle)
+        assert vehicles[0].id == 1
+        assert vehicles[0].price_cents == 5000000
+        assert vehicles[0].description == "Test vehicle"
+
+
+class TestStockUpdate:
+    @respx.mock
+    def test_update_returns_stock_vehicle(self, sync_client: CredereClient) -> None:
+        url = f"{VEHICLES_URL}/1"
+        route = respx.put(url).mock(
+            return_value=httpx.Response(200, json={"vehicle": SAMPLE_VEHICLE})
+        )
+
+        vehicle = sync_client.stock.update(1, SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(vehicle, StockVehicle)
+        assert vehicle.id == 1
+        assert vehicle.price_cents == 5000000
+        assert vehicle.description == "Test vehicle"
+
+
+class TestStockRemove:
+    @respx.mock
+    def test_remove_returns_stock_vehicle(self, sync_client: CredereClient) -> None:
+        url = f"{VEHICLES_URL}/1/remove_from_stock"
+        route = respx.put(url).mock(
+            return_value=httpx.Response(200, json={"vehicle": SAMPLE_VEHICLE})
+        )
+
+        vehicle = sync_client.stock.remove(1)
+
+        assert route.called
+        assert isinstance(vehicle, StockVehicle)
+        assert vehicle.id == 1
+        assert vehicle.price_cents == 5000000
+        assert vehicle.description == "Test vehicle"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        respx.get(VEHICLES_URL).mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.stock.list()
+
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    def test_404_raises_not_found_error(self, sync_client: CredereClient) -> None:
+        url = f"{VEHICLES_URL}/999/remove_from_stock"
+        respx.put(url).mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "message": "Endpoint requested not found",
+                        "status": 404,
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(NotFoundError) as exc_info:
+            sync_client.stock.remove(999)
+
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncStockCreate:
+    @respx.mock
+    async def test_async_create_returns_stock_vehicle(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.post(VEHICLES_URL).mock(
+            return_value=httpx.Response(200, json={"vehicle": SAMPLE_VEHICLE})
+        )
+
+        vehicle = await async_client.stock.create(SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(vehicle, StockVehicle)
+        assert vehicle.id == 1
+        assert vehicle.price_cents == 5000000
+        assert vehicle.description == "Test vehicle"
+
+
+class TestAsyncStockList:
+    @respx.mock
+    async def test_async_list_returns_stock_vehicles(
+        self, async_client: AsyncCredereClient
+    ) -> None:
+        route = respx.get(VEHICLES_URL).mock(
+            return_value=httpx.Response(200, json=[SAMPLE_VEHICLE])
+        )
+
+        vehicles = await async_client.stock.list()
+
+        assert route.called
+        assert isinstance(vehicles, list)
+        assert len(vehicles) == 1
+        assert isinstance(vehicles[0], StockVehicle)
+        assert vehicles[0].id == 1
+        assert vehicles[0].price_cents == 5000000
+        assert vehicles[0].description == "Test vehicle"


### PR DESCRIPTION
## Summary
- Add `Stock` and `AsyncStock` resource classes with create, list, update, and remove endpoints
- Add Pydantic models: `StockVehicle`, `StockVehicleCreateRequest`
- Wire into `CredereClient` / `AsyncCredereClient` and re-export from package

## Test plan
- [x] Sync tests for all 4 endpoints (create, list, update, remove)
- [x] Error mapping tests (401, 404)
- [x] Async tests (create, list)