### PR TITLE
Add Bank Credentials resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -9,6 +9,7 @@ from credere.exceptions import (
     CredereTimeoutError,
     NotFoundError,
 )
+from credere.models.bank_credentials import IntegratedBank
 from credere.models.leads import (
     Address,
     DomainValue,
@@ -62,6 +63,7 @@ __all__ = [
     "CredereTimeoutError",
     "Domain",
     "DomainValue",
+    "IntegratedBank",
     "Lead",
     "LeadAddress",
     "LeadCreateRequest",

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import httpx
 
 from credere.auth import APIKeyAuth
+from credere.resources.bank_credentials import AsyncBankCredentials, BankCredentials
 from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
 from credere.resources.proposals import AsyncProposals, Proposals
@@ -39,6 +40,7 @@ class CredereClient:
         self.leads = Leads(self._http, store_id=store_id)
         self.proposals = Proposals(self._http, store_id=store_id)
         self.simulations = Simulations(self._http, store_id=store_id)
+        self.bank_credentials = BankCredentials(self._http, store_id=store_id)
         self.stock = Stock(self._http, store_id=store_id)
         self.utilities = Utilities(self._http, store_id=store_id)
         self.vehicle_models = VehicleModels(self._http, store_id=store_id)
@@ -76,6 +78,7 @@ class AsyncCredereClient:
         self.leads = AsyncLeads(self._http, store_id=store_id)
         self.proposals = AsyncProposals(self._http, store_id=store_id)
         self.simulations = AsyncSimulations(self._http, store_id=store_id)
+        self.bank_credentials = AsyncBankCredentials(self._http, store_id=store_id)
         self.stock = AsyncStock(self._http, store_id=store_id)
         self.utilities = AsyncUtilities(self._http, store_id=store_id)
         self.vehicle_models = AsyncVehicleModels(self._http, store_id=store_id)

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -1,5 +1,6 @@
 """Pydantic models for the Credere SDK."""
 
+from credere.models.bank_credentials import IntegratedBank
 from credere.models.leads import (
     Address,
     DomainValue,
@@ -46,6 +47,7 @@ __all__ = [
     "Bank",
     "Domain",
     "DomainValue",
+    "IntegratedBank",
     "Lead",
     "LeadAddress",
     "LeadCreateRequest",

--- a/src/credere/models/bank_credentials.py
+++ b/src/credere/models/bank_credentials.py
@@ -1,0 +1,20 @@
+"""Pydantic models for the Bank Credentials resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from credere.models.simulations import Bank
+
+
+class IntegratedBank(BaseModel):
+    """Integrated bank as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    store_id: int | None = None
+    bank: Bank | None = None
+    credentials_status: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -1,5 +1,6 @@
 """Resource classes for the Credere SDK."""
 
+from credere.resources.bank_credentials import AsyncBankCredentials, BankCredentials
 from credere.resources.leads import AsyncLeads, Leads
 from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
 from credere.resources.proposals import AsyncProposals, Proposals
@@ -11,6 +12,7 @@ from credere.resources.utilities import AsyncUtilities, Utilities
 from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 
 __all__ = [
+    "AsyncBankCredentials",
     "AsyncLeads",
     "AsyncProposalAttempts",
     "AsyncProposals",
@@ -20,6 +22,7 @@ __all__ = [
     "AsyncUsers",
     "AsyncUtilities",
     "AsyncVehicleModels",
+    "BankCredentials",
     "Leads",
     "ProposalAttempts",
     "Proposals",

--- a/src/credere/resources/bank_credentials.py
+++ b/src/credere/resources/bank_credentials.py
@@ -1,0 +1,104 @@
+"""Sync and async resource classes for the Bank Credentials endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.bank_credentials import IntegratedBank
+
+
+class BankCredentials:
+    """Synchronous bank credentials resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def persist(
+        self,
+        store_id: int,
+    ) -> dict[str, Any]:
+        try:
+            response = self._client.get(
+                f"/v1/stores/{store_id}/persist_cnpj_bank_credentials",
+                headers=self._headers(),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return response.json()
+
+    def list(
+        self,
+        store_id: int,
+    ) -> list[IntegratedBank]:
+        try:
+            response = self._client.get(
+                f"/v1/stores/{store_id}/integrated_banks",
+                headers=self._headers(),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [
+            IntegratedBank.model_validate(item)
+            for item in response.json()["integrated_banks"]
+        ]
+
+
+class AsyncBankCredentials:
+    """Asynchronous bank credentials resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def persist(
+        self,
+        store_id: int,
+    ) -> dict[str, Any]:
+        try:
+            response = await self._client.get(
+                f"/v1/stores/{store_id}/persist_cnpj_bank_credentials",
+                headers=self._headers(),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return response.json()
+
+    async def list(
+        self,
+        store_id: int,
+    ) -> list[IntegratedBank]:
+        try:
+            response = await self._client.get(
+                f"/v1/stores/{store_id}/integrated_banks",
+                headers=self._headers(),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [
+            IntegratedBank.model_validate(item)
+            for item in response.json()["integrated_banks"]
+        ]

--- a/tests/test_bank_credentials.py
+++ b/tests/test_bank_credentials.py
@@ -1,0 +1,100 @@
+"""Tests for the BankCredentials resource (sync + async)."""
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError
+from credere.models.bank_credentials import IntegratedBank
+
+BASE_URL = "https://api.credere.com"
+STORE_ID = 99
+
+SAMPLE_INTEGRATED_BANK = {
+    "id": 1,
+    "store_id": 99,
+    "credentials_status": "active",
+    "created_at": "2024-01-15T10:00:00-03:00",
+    "updated_at": "2024-01-15T10:00:00-03:00",
+}
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestBankCredentialsPersist:
+    @respx.mock
+    def test_persist(self, sync_client: CredereClient) -> None:
+        route = respx.get(
+            f"{BASE_URL}/v1/stores/{STORE_ID}/persist_cnpj_bank_credentials"
+        ).mock(return_value=httpx.Response(200, json={"status": "ok"}))
+
+        result = sync_client.bank_credentials.persist(STORE_ID)
+
+        assert route.called
+        assert result == {"status": "ok"}
+
+
+class TestBankCredentialsList:
+    @respx.mock
+    def test_list(self, sync_client: CredereClient) -> None:
+        route = respx.get(f"{BASE_URL}/v1/stores/{STORE_ID}/integrated_banks").mock(
+            return_value=httpx.Response(
+                200,
+                json={"integrated_banks": [SAMPLE_INTEGRATED_BANK]},
+            )
+        )
+
+        result = sync_client.bank_credentials.list(STORE_ID)
+
+        assert route.called
+        assert len(result) == 1
+        assert isinstance(result[0], IntegratedBank)
+        assert result[0].credentials_status == "active"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        respx.get(f"{BASE_URL}/v1/stores/{STORE_ID}/integrated_banks").mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.bank_credentials.list(STORE_ID)
+
+        assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncBankCredentialsList:
+    @respx.mock
+    async def test_async_list(self, async_client: AsyncCredereClient) -> None:
+        route = respx.get(f"{BASE_URL}/v1/stores/{STORE_ID}/integrated_banks").mock(
+            return_value=httpx.Response(
+                200,
+                json={"integrated_banks": [SAMPLE_INTEGRATED_BANK]},
+            )
+        )
+
+        result = await async_client.bank_credentials.list(STORE_ID)
+
+        assert route.called
+        assert len(result) == 1
+        assert isinstance(result[0], IntegratedBank)
+        assert result[0].credentials_status == "active"


### PR DESCRIPTION
## Summary
- Add `BankCredentials` and `AsyncBankCredentials` resource classes with persist and list endpoints
- Add Pydantic model: `IntegratedBank` (reuses `Bank` from simulations module)
- Wire into `CredereClient` / `AsyncCredereClient` and re-export from package

## Test plan
- [x] Sync tests for both endpoints (persist, list)
- [x] Error mapping test (401)
- [x] Async test (list)