### PR TITLE
Add Plus Returns resource

### DIFF
--- a/src/credere/__init__.py
+++ b/src/credere/__init__.py
@@ -18,6 +18,7 @@ from credere.models.leads import (
     LeadCreateRequest,
     LeadRequiredFields,
 )
+from credere.models.plus_returns import PlusReturnRule, PlusReturnRuleCreateRequest
 from credere.models.proposal_attempts import (
     ProposalAttempt,
     ProposalAttemptCreateRequest,
@@ -69,6 +70,8 @@ __all__ = [
     "LeadCreateRequest",
     "LeadRequiredFields",
     "NotFoundError",
+    "PlusReturnRule",
+    "PlusReturnRuleCreateRequest",
     "Proposal",
     "ProposalAttempt",
     "ProposalAttemptCreateRequest",

--- a/src/credere/client.py
+++ b/src/credere/client.py
@@ -7,6 +7,7 @@ import httpx
 from credere.auth import APIKeyAuth
 from credere.resources.bank_credentials import AsyncBankCredentials, BankCredentials
 from credere.resources.leads import AsyncLeads, Leads
+from credere.resources.plus_returns import AsyncPlusReturns, PlusReturns
 from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
@@ -41,6 +42,7 @@ class CredereClient:
         self.proposals = Proposals(self._http, store_id=store_id)
         self.simulations = Simulations(self._http, store_id=store_id)
         self.bank_credentials = BankCredentials(self._http, store_id=store_id)
+        self.plus_returns = PlusReturns(self._http, store_id=store_id)
         self.stock = Stock(self._http, store_id=store_id)
         self.utilities = Utilities(self._http, store_id=store_id)
         self.vehicle_models = VehicleModels(self._http, store_id=store_id)
@@ -79,6 +81,7 @@ class AsyncCredereClient:
         self.proposals = AsyncProposals(self._http, store_id=store_id)
         self.simulations = AsyncSimulations(self._http, store_id=store_id)
         self.bank_credentials = AsyncBankCredentials(self._http, store_id=store_id)
+        self.plus_returns = AsyncPlusReturns(self._http, store_id=store_id)
         self.stock = AsyncStock(self._http, store_id=store_id)
         self.utilities = AsyncUtilities(self._http, store_id=store_id)
         self.vehicle_models = AsyncVehicleModels(self._http, store_id=store_id)

--- a/src/credere/models/__init__.py
+++ b/src/credere/models/__init__.py
@@ -9,6 +9,7 @@ from credere.models.leads import (
     LeadCreateRequest,
     LeadRequiredFields,
 )
+from credere.models.plus_returns import PlusReturnRule, PlusReturnRuleCreateRequest
 from credere.models.proposal_attempts import (
     ProposalAttempt,
     ProposalAttemptCreateRequest,
@@ -52,6 +53,8 @@ __all__ = [
     "LeadAddress",
     "LeadCreateRequest",
     "LeadRequiredFields",
+    "PlusReturnRule",
+    "PlusReturnRuleCreateRequest",
     "Proposal",
     "ProposalAttempt",
     "ProposalAttemptCreateRequest",

--- a/src/credere/models/plus_returns.py
+++ b/src/credere/models/plus_returns.py
@@ -1,0 +1,21 @@
+"""Pydantic models for the Plus Returns resource."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PlusReturnRuleCreateRequest(BaseModel):
+    """Input model for creating or updating a plus return rule."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+class PlusReturnRule(BaseModel):
+    """Plus return rule as returned by the API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None

--- a/src/credere/resources/__init__.py
+++ b/src/credere/resources/__init__.py
@@ -2,6 +2,7 @@
 
 from credere.resources.bank_credentials import AsyncBankCredentials, BankCredentials
 from credere.resources.leads import AsyncLeads, Leads
+from credere.resources.plus_returns import AsyncPlusReturns, PlusReturns
 from credere.resources.proposal_attempts import AsyncProposalAttempts, ProposalAttempts
 from credere.resources.proposals import AsyncProposals, Proposals
 from credere.resources.simulations import AsyncSimulations, Simulations
@@ -14,6 +15,7 @@ from credere.resources.vehicle_models import AsyncVehicleModels, VehicleModels
 __all__ = [
     "AsyncBankCredentials",
     "AsyncLeads",
+    "AsyncPlusReturns",
     "AsyncProposalAttempts",
     "AsyncProposals",
     "AsyncSimulations",
@@ -24,6 +26,7 @@ __all__ = [
     "AsyncVehicleModels",
     "BankCredentials",
     "Leads",
+    "PlusReturns",
     "ProposalAttempts",
     "Proposals",
     "Simulations",

--- a/src/credere/resources/plus_returns.py
+++ b/src/credere/resources/plus_returns.py
@@ -1,0 +1,270 @@
+"""Sync and async resource classes for the Plus Returns endpoint."""
+
+from __future__ import annotations
+
+import httpx
+
+from credere._response import handle_request_error, raise_for_status
+from credere.models.plus_returns import PlusReturnRule, PlusReturnRuleCreateRequest
+
+_BASE_PATH = "/v1/plus_return_rules"
+
+
+class PlusReturns:
+    """Synchronous plus returns resource."""
+
+    def __init__(self, client: httpx.Client, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    def create(
+        self,
+        data: PlusReturnRuleCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = self._client.post(
+                _BASE_PATH,
+                json={"plus_return_rule": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+    def list(self, *, store_id: int | None = None) -> list[PlusReturnRule]:
+        try:
+            response = self._client.get(
+                _BASE_PATH,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [PlusReturnRule.model_validate(item) for item in response.json()]
+
+    def get(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = self._client.get(
+                f"{_BASE_PATH}/{id}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+    def update(
+        self,
+        id: int,
+        data: PlusReturnRuleCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = self._client.patch(
+                f"{_BASE_PATH}/{id}",
+                json={"plus_return_rule": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+    def delete(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> None:
+        try:
+            response = self._client.delete(
+                f"{_BASE_PATH}/{id}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+
+    def activate(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = self._client.get(
+                f"{_BASE_PATH}/{id}/activate",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+    def deactivate(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = self._client.get(
+                f"{_BASE_PATH}/{id}/deactivate",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+
+class AsyncPlusReturns:
+    """Asynchronous plus returns resource."""
+
+    def __init__(self, client: httpx.AsyncClient, store_id: int | None = None) -> None:
+        self._client = client
+        self._store_id = store_id
+
+    def _headers(self, store_id: int | None = None) -> dict[str, str]:
+        sid = store_id if store_id is not None else self._store_id
+        if sid is not None:
+            return {"Store-Id": str(sid)}
+        return {}
+
+    async def create(
+        self,
+        data: PlusReturnRuleCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = await self._client.post(
+                _BASE_PATH,
+                json={"plus_return_rule": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+    async def list(self, *, store_id: int | None = None) -> list[PlusReturnRule]:
+        try:
+            response = await self._client.get(
+                _BASE_PATH,
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return [PlusReturnRule.model_validate(item) for item in response.json()]
+
+    async def get(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = await self._client.get(
+                f"{_BASE_PATH}/{id}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+    async def update(
+        self,
+        id: int,
+        data: PlusReturnRuleCreateRequest,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = await self._client.patch(
+                f"{_BASE_PATH}/{id}",
+                json={"plus_return_rule": data.model_dump(exclude_none=True)},
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+    async def delete(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> None:
+        try:
+            response = await self._client.delete(
+                f"{_BASE_PATH}/{id}",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+
+    async def activate(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = await self._client.get(
+                f"{_BASE_PATH}/{id}/activate",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])
+
+    async def deactivate(
+        self,
+        id: int,
+        *,
+        store_id: int | None = None,
+    ) -> PlusReturnRule:
+        try:
+            response = await self._client.get(
+                f"{_BASE_PATH}/{id}/deactivate",
+                headers=self._headers(store_id),
+            )
+        except httpx.HTTPError as exc:
+            handle_request_error(exc)
+            raise
+        raise_for_status(response)
+        return PlusReturnRule.model_validate(response.json()["plus_return_rule"])

--- a/tests/test_plus_returns.py
+++ b/tests/test_plus_returns.py
@@ -1,0 +1,239 @@
+"""Tests for the Plus Returns resource (sync + async)."""
+
+import httpx
+import pytest
+import respx
+
+from credere.client import AsyncCredereClient, CredereClient
+from credere.exceptions import AuthenticationError, NotFoundError
+from credere.models.plus_returns import PlusReturnRule, PlusReturnRuleCreateRequest
+
+BASE_URL = "https://api.credere.com"
+RULES_URL = f"{BASE_URL}/v1/plus_return_rules"
+
+SAMPLE_RULE_RESPONSE = {
+    "plus_return_rule": {
+        "id": 1,
+        "created_at": "2024-01-01",
+        "updated_at": "2024-01-01",
+    }
+}
+
+SAMPLE_LIST_RESPONSE = [SAMPLE_RULE_RESPONSE["plus_return_rule"]]
+
+SAMPLE_CREATE_DATA = PlusReturnRuleCreateRequest()
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlusReturnsCreate:
+    @respx.mock
+    def test_create(self, sync_client: CredereClient) -> None:
+        route = respx.post(RULES_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_RULE_RESPONSE)
+        )
+
+        result = sync_client.plus_returns.create(SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(result, PlusReturnRule)
+        assert result.id == 1
+        assert result.created_at == "2024-01-01"
+        assert result.updated_at == "2024-01-01"
+
+
+class TestPlusReturnsList:
+    @respx.mock
+    def test_list(self, sync_client: CredereClient) -> None:
+        route = respx.get(RULES_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_LIST_RESPONSE)
+        )
+
+        result = sync_client.plus_returns.list()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], PlusReturnRule)
+        assert result[0].id == 1
+
+
+class TestPlusReturnsGet:
+    @respx.mock
+    def test_get(self, sync_client: CredereClient) -> None:
+        url = f"{RULES_URL}/1"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_RULE_RESPONSE)
+        )
+
+        result = sync_client.plus_returns.get(1)
+
+        assert route.called
+        assert isinstance(result, PlusReturnRule)
+        assert result.id == 1
+        assert result.created_at == "2024-01-01"
+
+
+class TestPlusReturnsUpdate:
+    @respx.mock
+    def test_update(self, sync_client: CredereClient) -> None:
+        url = f"{RULES_URL}/1"
+        route = respx.patch(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_RULE_RESPONSE)
+        )
+
+        result = sync_client.plus_returns.update(1, SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(result, PlusReturnRule)
+        assert result.id == 1
+
+
+class TestPlusReturnsDelete:
+    @respx.mock
+    def test_delete(self, sync_client: CredereClient) -> None:
+        route = respx.delete(f"{RULES_URL}/1").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        result = sync_client.plus_returns.delete(1)
+
+        assert route.called
+        assert result is None
+
+
+class TestPlusReturnsActivate:
+    @respx.mock
+    def test_activate(self, sync_client: CredereClient) -> None:
+        url = f"{RULES_URL}/1/activate"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_RULE_RESPONSE)
+        )
+
+        result = sync_client.plus_returns.activate(1)
+
+        assert route.called
+        assert isinstance(result, PlusReturnRule)
+        assert result.id == 1
+
+
+class TestPlusReturnsDeactivate:
+    @respx.mock
+    def test_deactivate(self, sync_client: CredereClient) -> None:
+        url = f"{RULES_URL}/1/deactivate"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_RULE_RESPONSE)
+        )
+
+        result = sync_client.plus_returns.deactivate(1)
+
+        assert route.called
+        assert isinstance(result, PlusReturnRule)
+        assert result.id == 1
+
+
+# ---------------------------------------------------------------------------
+# Error mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMapping:
+    @respx.mock
+    def test_401_raises_authentication_error(self, sync_client: CredereClient) -> None:
+        respx.get(RULES_URL).mock(
+            return_value=httpx.Response(
+                401,
+                json={"error": {"message": "Unauthorized", "status": 401}},
+            )
+        )
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            sync_client.plus_returns.list()
+
+        assert exc_info.value.status_code == 401
+
+    @respx.mock
+    def test_404_raises_not_found_error(self, sync_client: CredereClient) -> None:
+        url = f"{RULES_URL}/999"
+        respx.get(url).mock(
+            return_value=httpx.Response(
+                404,
+                json={
+                    "error": {
+                        "message": "Endpoint requested not found",
+                        "status": 404,
+                    }
+                },
+            )
+        )
+
+        with pytest.raises(NotFoundError) as exc_info:
+            sync_client.plus_returns.get(999)
+
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Async tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncPlusReturnsCreate:
+    @respx.mock
+    async def test_async_create(self, async_client: AsyncCredereClient) -> None:
+        route = respx.post(RULES_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_RULE_RESPONSE)
+        )
+
+        result = await async_client.plus_returns.create(SAMPLE_CREATE_DATA)
+
+        assert route.called
+        assert isinstance(result, PlusReturnRule)
+        assert result.id == 1
+        assert result.created_at == "2024-01-01"
+
+
+class TestAsyncPlusReturnsList:
+    @respx.mock
+    async def test_async_list(self, async_client: AsyncCredereClient) -> None:
+        route = respx.get(RULES_URL).mock(
+            return_value=httpx.Response(200, json=SAMPLE_LIST_RESPONSE)
+        )
+
+        result = await async_client.plus_returns.list()
+
+        assert route.called
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert isinstance(result[0], PlusReturnRule)
+
+
+class TestAsyncPlusReturnsGet:
+    @respx.mock
+    async def test_async_get(self, async_client: AsyncCredereClient) -> None:
+        url = f"{RULES_URL}/1"
+        route = respx.get(url).mock(
+            return_value=httpx.Response(200, json=SAMPLE_RULE_RESPONSE)
+        )
+
+        result = await async_client.plus_returns.get(1)
+
+        assert route.called
+        assert isinstance(result, PlusReturnRule)
+        assert result.id == 1
+
+
+class TestAsyncPlusReturnsDelete:
+    @respx.mock
+    async def test_async_delete(self, async_client: AsyncCredereClient) -> None:
+        route = respx.delete(f"{RULES_URL}/1").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        result = await async_client.plus_returns.delete(1)
+
+        assert route.called
+        assert result is None


### PR DESCRIPTION
## Summary
- Add `PlusReturns` and `AsyncPlusReturns` resource classes with create, list, get, update, delete, activate, and deactivate endpoints
- Add Pydantic models: `PlusReturnRule`, `PlusReturnRuleCreateRequest`
- Wire into `CredereClient` / `AsyncCredereClient` and re-export from package

## Test plan
- [x] Sync tests for all 7 endpoints
- [x] Error mapping tests (401, 404)
- [x] Async tests (create, list, get, delete)