### PR TITLE
feat: add include_personal_insurance to ProductsOptions

### DIFF
--- a/src/credere/models/simulations.py
+++ b/src/credere/models/simulations.py
@@ -12,6 +12,7 @@ class RetrieveLead(BaseModel):
 class ProductsOptions(BaseModel):
     include_capitalization_bond: bool | None = None
     include_asset_insurance: bool | None = None
+    include_personal_insurance: bool | None = None
 
 
 class Vehicle(BaseModel):


### PR DESCRIPTION
Align simulation ProductsOptions with embed configuration docs, which list include_personal_insurance alongside the existing capitalization bond and asset insurance flags.